### PR TITLE
refactor: removing tailwind for animation

### DIFF
--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,5 +1,18 @@
 import { Variants } from 'framer-motion';
 
+export const extendWidth: Variants = {
+    initial: {
+        width: '0%',
+    },
+    animate: {
+        width: '100%',
+        transition: {
+            duration: 0.7,
+            ease: 'linear',
+        },
+    },
+};
+
 export const mainContainer: Variants = {
     hidden: { y: '2%', opacity: 0 },
     show: {

--- a/src/screens/LoadingScreen.tsx
+++ b/src/screens/LoadingScreen.tsx
@@ -1,8 +1,16 @@
+import { motion } from 'framer-motion';
+import { extendWidth } from '../lib/animations.ts';
+
 export default function LoadingScreen() {
     return (
         <div className="flex h-full w-full items-center justify-center">
             <div className="relative h-1 w-32 overflow-hidden rounded-full bg-slate-200">
-                <div className="absolute h-full animate-extendWidth bg-slate-900"></div>
+                <motion.div
+                    variants={extendWidth}
+                    initial="initial"
+                    animate="animate"
+                    className="absolute h-full bg-slate-900"
+                ></motion.div>
             </div>
         </div>
     );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,17 +2,7 @@
 export default {
     content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
     theme: {
-        extend: {
-            animation: {
-                extendWidth: 'extendWidth 0.7s linear forwards',
-            },
-            keyframes: {
-                extendWidth: {
-                    '0%': { width: '0%' },
-                    '100%': { width: '100%' },
-                },
-            },
-        },
+        extend: {},
     },
     plugins: [],
 };


### PR DESCRIPTION
This commit removes the extend width animation configuration from the `tailwind.config.js` file, and instead replaces it with the framer motion equivalent.

This is just so that it is consistent across the application.